### PR TITLE
Fixed orderbook priceStep dropdown items order

### DIFF
--- a/src/components/market/OrderBook/OrderBookToolbar.tsx
+++ b/src/components/market/OrderBook/OrderBookToolbar.tsx
@@ -34,15 +34,17 @@ export const OrderBookToolbar = ({ disabled }: OrderBookToolbarProps): ReactElem
                 {priceStep}
             </Dropdown.Button>
             <Dropdown.Menu align="right">
-                {Object.keys(OrderBookPriceStep).map(x => (
-                    <Dropdown.Item
-                        key={x}
-                        onSelect={() => setPriceStep(x as keyof typeof OrderBookPriceStep)}
-                        active={x === priceStep}
-                    >
-                        <span>{x}</span>
-                    </Dropdown.Item>
-                ))}
+                {Object.keys(OrderBookPriceStep)
+                    .sort()
+                    .map(x => (
+                        <Dropdown.Item
+                            key={x}
+                            onSelect={() => setPriceStep(x as keyof typeof OrderBookPriceStep)}
+                            active={x === priceStep}
+                        >
+                            <span>{x}</span>
+                        </Dropdown.Item>
+                    ))}
             </Dropdown.Menu>
         </Dropdown>
     );


### PR DESCRIPTION
Place orderbook priceStep dropdown items in correct order (from lowest to highest), making it clearer to user.