### PR TITLE
Test workflow trigger changed to push/workflow_dispatch

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,7 +2,11 @@ name: Test
 
 on:
   # Triggers the workflow on every pull-request
-  pull_request:
+  push:
+    branches:
+      - "master"
+  # Allows to trigger workflow manually
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
Impove dx by removing test stand update on every pull-request, instead of that update it only after push to master branch or manually (from any branch if needed).