### PR TITLE
Fixed Sentry cluttered extensions errors

### DIFF
--- a/src/sentry.ts
+++ b/src/sentry.ts
@@ -26,5 +26,10 @@ export const configureSentry = (): void => {
         dsn,
         integrations: [new BrowserTracing()],
         tracesSampleRate: 0.2,
+        denyUrls: [
+            // Chrome extensions
+            /extensions\//i,
+            /^chrome:\/\//i,
+        ],
     });
 };


### PR DESCRIPTION
Disable chrome extensions errors cathcing by adding denyUrls section. 