### PR TITLE
Added vite-plugin-compression

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -74,6 +74,7 @@
         "terser": "^5.16.6",
         "typescript": "^4.4.4",
         "vite": "^4.2.0",
+        "vite-plugin-compression": "^0.5.1",
         "vite-plugin-eslint": "^1.8.1",
         "vite-plugin-html": "^3.2.0"
       }
@@ -8327,6 +8328,20 @@
         }
       }
     },
+    "node_modules/vite-plugin-compression": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/vite-plugin-compression/-/vite-plugin-compression-0.5.1.tgz",
+      "integrity": "sha512-5QJKBDc+gNYVqL/skgFAP81Yuzo9R+EAf19d+EtsMF/i8kFUpNi3J/H01QD3Oo8zBQn+NzoCIFkpPLynoOzaJg==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "debug": "^4.3.3",
+        "fs-extra": "^10.0.0"
+      },
+      "peerDependencies": {
+        "vite": ">=2.0.0"
+      }
+    },
     "node_modules/vite-plugin-eslint": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/vite-plugin-eslint/-/vite-plugin-eslint-1.8.1.tgz",
@@ -14543,6 +14558,17 @@
         "postcss": "^8.4.21",
         "resolve": "^1.22.1",
         "rollup": "^3.18.0"
+      }
+    },
+    "vite-plugin-compression": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/vite-plugin-compression/-/vite-plugin-compression-0.5.1.tgz",
+      "integrity": "sha512-5QJKBDc+gNYVqL/skgFAP81Yuzo9R+EAf19d+EtsMF/i8kFUpNi3J/H01QD3Oo8zBQn+NzoCIFkpPLynoOzaJg==",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.1.2",
+        "debug": "^4.3.3",
+        "fs-extra": "^10.0.0"
       }
     },
     "vite-plugin-eslint": {

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "terser": "^5.16.6",
     "typescript": "^4.4.4",
     "vite": "^4.2.0",
+    "vite-plugin-compression": "^0.5.1",
     "vite-plugin-eslint": "^1.8.1",
     "vite-plugin-html": "^3.2.0"
   }

--- a/vite.config.js
+++ b/vite.config.js
@@ -5,6 +5,7 @@ import path from 'path';
 import { createHtmlPlugin } from 'vite-plugin-html';
 import legacy from '@vitejs/plugin-legacy';
 import eslint from 'vite-plugin-eslint';
+import viteCompression from 'vite-plugin-compression';
 
 export default defineConfig({
     resolve: {
@@ -24,6 +25,7 @@ export default defineConfig({
                 'core-js/stable'
             ],
         }),
+        viteCompression(),
     ],
     build: {
         outDir: 'build',


### PR DESCRIPTION
Use [vite-plugin-compression](https://www.npmjs.com/package/vite-plugin-compression) to gzip build results.

Related
#95 
Nilfoundation/proof-market#33