### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,6 +25,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
 
     - name: Get version
       id: get_version


### PR DESCRIPTION
This diff sets `fetch-deps` checkout workflow step as 0 to fetch all tags, because it is required for `git describe` to work properly.