### PR TITLE
Add concurrency block to deploy test stand workflow

### DIFF
--- a/.github/workflows/deploy_test.yaml
+++ b/.github/workflows/deploy_test.yaml
@@ -14,6 +14,14 @@ on:
         default: ''
         type: string
 
+concurrency:
+  group: ${{
+    ( github.ref == 'refs/heads/master' &&
+    format('{0}/{1}', github.run_id, github.run_attempt) )
+    ||
+    format('{0}/{1}', github.workflow, github.ref) }}
+  cancel-in-progress: true
+
 jobs:
   build:
     uses: ./.github/workflows/build.yaml


### PR DESCRIPTION
This diff adds simple concurrency block to cancel already running workflows
I didn't add it to deploy to production workflow in order not to produce some unexpected side effects of partial deploy.